### PR TITLE
Symbol detection disabling/enabling feature

### DIFF
--- a/src/kivy_garden/zbarcam/zbarcam.py
+++ b/src/kivy_garden/zbarcam/zbarcam.py
@@ -78,6 +78,14 @@ class ZBarCam(AnchorLayout):
                 ),
             ).start()
 
+    def disable_scanning(self):
+        # Disabling necessary when using zbarcam in a multiple xcamera app
+        self.xcamera._camera.unbind(on_texture=self._on_texture)
+
+    def enable_scanning(self):
+        # When symbol detection is necessary again after self.disable_scanning
+        self._on_camera_ready(xcamera=self.xcamera)
+
     def _threaded_detect_qrcode_frame(self, texture, pixels, code_types):
         self._symbols_queue.put(
             self._detect_qrcode_frame(texture, code_types, pixels)


### PR DESCRIPTION
You get trouble when writing an app with two xcamera instances. The best solution is to copy the texture of one of them and use it in an Image instead of having two xcamera instances. But when the second instance is meant to take a picture, you do not need the symbol detection capabilities. That's why a enable/disable scanning method would be handy.